### PR TITLE
Int column options

### DIFF
--- a/R/read_movement_data.R
+++ b/R/read_movement_data.R
@@ -28,25 +28,20 @@ reformat_move_data <- function(move_data_file, delim = NULL, datetime_format = "
   #read in datafile (all columns), with col type initially character for all columns
   all_data <- read_delim(move_data_file, delim = delim, col_types = cols(.default = col_character()))
 
-
-  # FOR INTEGER COLUMN INDICES:
-  # - minvars and extra can be changed to read colnames from data
-  # - BUT can't quite check whether right column has been selected
-  # - need to include range check: that cols for minvars are within range of
-
-
   #select columns of interest
   minvars <- movenetenv$options$movement_data[min_move_keys] #mandatory
   extra <- movenetenv$options$movement_data[is.na(match(names(movenetenv$options$movement_data),min_move_keys))] #optional
   #convert options with integer values (column indices) to column names
-  if(any(is.integer(unlist(movenetenv$options$movement_data)))){
-    colindex2name(data = all_data, minvars = minvars, extra = extra)
+  if(any(sapply(movenetenv$options$movement_data,is.integer))){
+    opt_w_names <- colindex2name(data = all_data, minvars = minvars, extra = extra)
+    minvars <- opt_w_names[[1]]
+    extra <- opt_w_names[[2]]
   }
   selected_data <- select_cols(data = all_data, minvars = minvars, extra = extra)
 
   #check data & change col types; or raise informative errors
-  selected_data[minvars$movenet.nr_pigs] <- reformat_nrpigs(selected_data[minvars$movenet.nr_pigs]) #this goes wrong with ints
-  selected_data[minvars$movenet.move_date] <- reformat_date(selected_data[minvars$movenet.move_date], datetime_format = datetime_format) #this goes wrong with ints
+  selected_data[minvars$movenet.nr_pigs] <- reformat_nrpigs(selected_data[minvars$movenet.nr_pigs])
+  selected_data[minvars$movenet.move_date] <- reformat_date(selected_data[minvars$movenet.move_date], datetime_format = datetime_format)
   if (length(selected_data) > 4){
     selected_data[unlist(extra[extra %in% names(selected_data)])] <- suppressMessages(type_convert(selected_data[unlist(extra[extra %in% names(selected_data)])])) #guess coltype of extra columns
   }
@@ -55,17 +50,35 @@ reformat_move_data <- function(move_data_file, delim = NULL, datetime_format = "
 }
 
 colindex2name <- function(data, minvars, extra){
-
+  if (any(sapply(minvars, is.integer))){
+    if (any(sapply(minvars, function(x) (is.integer(x) & x > length(data))))){
+      outofrange_minvars <- minvars[which(sapply(minvars, function(x) (is.integer(x) & x > length(data))))]
+      stop(sprintf("Can't find the following mandatory columns in the datafile: %s.\nThese column indices exceed the number of columns in the datafile.",
+                   paste0("#",outofrange_minvars," (",names(outofrange_minvars),")", collapse = ", ")), call. = FALSE)
+    }
+    minvars[names(minvars[which(sapply(minvars, is.integer))])] <- colnames(data)[unlist(minvars[which(sapply(minvars, is.integer))])]
+  }
+  if (any(sapply(extra, is.integer))){
+    if (any(sapply(extra, function(x) (is.integer(x) & x > length(data))))){
+      outofrange_extra <- extra[which(sapply(extra, function(x) (is.integer(x) & x > length(data))))]
+      warning(sprintf("Can't find the following requested optional columns in the datafile: %s.\nThese column indices exceed the number of columns in the datafile.\nProceeding without missing optional columns.",
+                      paste0("#",outofrange_extra," (",names(outofrange_extra),")", collapse = ", ")), call. = FALSE)
+      extra[which(extra %in% outofrange_extra)] <- NULL
+    }
+    withinrange_extra <- extra[which(sapply(extra, function(x) (is.integer(x) & x <= length(data))))]
+    extra[names(extra[which(extra %in% withinrange_extra)])] <- colnames(data)[unlist(withinrange_extra)]
+  }
+  return(list(minvars,extra))
 }
 
 select_cols <- function(data, minvars, extra){
-  if (!(all(unlist(minvars) %in% colnames(data)))){ #
-    missing_minvars <- unname(unlist(minvars))[which(!(unlist(minvars) %in% colnames(data)))] #this goes wrong with ints
+  if (!(all(unlist(minvars) %in% colnames(data)))){
+    missing_minvars <- unname(unlist(minvars))[which(!(unlist(minvars) %in% colnames(data)))]
     stop(sprintf("Can't find the following mandatory columns in the datafile: %s.", paste0(missing_minvars, collapse=", ")), call. = FALSE)
   }
-  if (!(all(unlist(extra) %in% colnames(data)))){ #this goes wrong with ints
-    missing_extra <- unname(unlist(extra))[which(!(unlist(extra) %in% colnames(data)))] #this goes wrong with ints
-    warning(sprintf("Can't find the following requested optional columns in the datafile: %s.\n Proceeding without missing optional columns.",
+  if (!(all(unlist(extra) %in% colnames(data)))){
+    missing_extra <- unname(unlist(extra))[which(!(unlist(extra) %in% colnames(data)))]
+    warning(sprintf("Can't find the following requested optional columns in the datafile: %s.\nProceeding without missing optional columns.",
                     paste0(missing_extra, collapse=", ")),
             call. = FALSE)
     to_extract <- unname(unlist(c(minvars,extra)))[-which(unname(unlist(c(minvars,extra))) %in% missing_extra)]

--- a/inst/configurations/ScotEID_mincolnrs.yml
+++ b/inst/configurations/ScotEID_mincolnrs.yml
@@ -1,0 +1,5 @@
+movement_data:
+  movenet.origin_ID: 14 #Column name or number for Identifier of origin holding/establishment/..
+  movenet.dest_ID: 19 #Column name or number for Identifier of destination holding/establishment/..
+  movenet.move_date: 5 #Column name or number for Date of transport (if multiple date types are available, use the one deemed most appropriate)
+  movenet.nr_pigs: 7 #Column name or number for Number of pigs transported

--- a/inst/configurations/ScotEID_mincolnrtoolarge.yml
+++ b/inst/configurations/ScotEID_mincolnrtoolarge.yml
@@ -1,0 +1,7 @@
+movement_data:
+  movenet.move_ID: 1 #Column name or number for Transport identifier
+  movenet.origin_ID: "departure_cph" #Column name or number for Identifier of origin holding/establishment/..
+  movenet.dest_ID: 20 #Column name or number for Identifier of destination holding/establishment/..
+  movenet.move_date: 5 #Column name or number for Date of transport (if multiple date types are available, use the one deemed most appropriate)
+  movenet.nr_pigs: 7 #Column name or number for Number of pigs transported
+  movenet.move_ref: "foreign_reference"

--- a/inst/configurations/ScotEID_mixcolnamesnrs.yml
+++ b/inst/configurations/ScotEID_mixcolnamesnrs.yml
@@ -1,0 +1,7 @@
+movement_data:
+  movenet.move_ID: 1 #Column name or number for Transport identifier
+  movenet.origin_ID: "departure_cph" #Column name or number for Identifier of origin holding/establishment/..
+  movenet.dest_ID: 19 #Column name or number for Identifier of destination holding/establishment/..
+  movenet.move_date: 5 #Column name or number for Date of transport (if multiple date types are available, use the one deemed most appropriate)
+  movenet.nr_pigs: 7 #Column name or number for Number of pigs transported
+  movenet.move_ref: "foreign_reference"

--- a/inst/configurations/ScotEID_optcolnrtoolarge.yml
+++ b/inst/configurations/ScotEID_optcolnrtoolarge.yml
@@ -1,0 +1,7 @@
+movement_data:
+  movenet.move_ID: 20 #Column name or number for Transport identifier
+  movenet.origin_ID: "departure_cph" #Column name or number for Identifier of origin holding/establishment/..
+  movenet.dest_ID: 19 #Column name or number for Identifier of destination holding/establishment/..
+  movenet.move_date: 5 #Column name or number for Date of transport (if multiple date types are available, use the one deemed most appropriate)
+  movenet.nr_pigs: 7 #Column name or number for Number of pigs transported
+  movenet.move_ref: "foreign_reference"

--- a/tests/testthat/test-read_movement_data.R
+++ b/tests/testthat/test-read_movement_data.R
@@ -4,7 +4,6 @@ ScotEID_config <- yaml.load_file(system.file("configurations", "ScotEID.yml", pa
 ScotEID_movedata <- ScotEID_config$movement_data
 ScotEID_colnames <- unlist(unname(ScotEID_movedata[c("movenet.origin_ID","movenet.dest_ID","movenet.move_date","movenet.nr_pigs","movenet.move_ID")]))
 
-
 test_that("when config has all min cols only, and input has implicit iso dateformat + int nr_pigs, output is data.frame with correct colnames & coltypes", {
   move_ID <- movenetenv$options$movement_data$movenet.move_ID
   movenetenv$options$movement_data$movenet.move_ID<-NULL
@@ -26,6 +25,34 @@ test_that("when config has min cols + extra move_ID col, and input has numeric m
   expect_type(output[[ScotEID_movedata$movenet.move_ID]], "double")
   })
 
+test_that("when config has all min cols, indicated as col indices, output is data.frame with correct colnames & coltypes",{
+  suppressMessages(load_config("ScotEID_mincolnrs"))
+  output <- expect_condition(reformat_move_data("test_input_files/ScotEID_testdata.csv"), NA)
+  expect_s3_class(output,"data.frame")
+  expect_named(output,ScotEID_colnames[c(1:4)])
+  expect_type(output[[ScotEID_movedata$movenet.origin_ID]], "character")
+  expect_type(output[[ScotEID_movedata$movenet.dest_ID]], "character")
+  expect_s3_class(output[[ScotEID_movedata$movenet.move_date]], "POSIXct") #this also works for wrong datetime formats though
+  expect_true(all(!is.na(output[[ScotEID_movedata$movenet.move_date]]))) #tests that all dates are interpretable = no NAs generated
+  expect_type(output[[ScotEID_movedata$movenet.nr_pigs]], "integer")
+  suppressMessages(load_config("ScotEID"))
+})
+
+test_that("when config has all min cols + extra col, with some of both indicated as col indices, output is data.frame with correct colnames & coltypes",{
+  suppressMessages(load_config("ScotEID_mixcolnamesnrs"))
+  output <- expect_condition(reformat_move_data("test_input_files/ScotEID_testdata.csv"), NA)
+  expect_s3_class(output,"data.frame")
+  expect_named(output,c(ScotEID_colnames,"foreign_reference"))
+  expect_type(output[[ScotEID_movedata$movenet.origin_ID]], "character")
+  expect_type(output[[ScotEID_movedata$movenet.dest_ID]], "character")
+  expect_s3_class(output[[ScotEID_movedata$movenet.move_date]], "POSIXct") #this also works for wrong datetime formats though
+  expect_true(all(!is.na(output[[ScotEID_movedata$movenet.move_date]]))) #tests that all dates are interpretable = no NAs generated
+  expect_type(output[[ScotEID_movedata$movenet.nr_pigs]], "integer")
+  expect_type(output[[ScotEID_movedata$movenet.move_ID]], "double")
+  expect_type(output[["foreign_reference"]], "character")
+  suppressMessages(load_config("ScotEID"))
+})
+
 #remove if dealt with at the change_config stage, otherwise add similar test/behaviour for non-char/non-int values
 test_that("when config misses a min col, an error is raised", {
   origin_ID <- movenetenv$options$movement_data$movenet.origin_ID
@@ -34,24 +61,21 @@ test_that("when config misses a min col, an error is raised", {
   movenetenv$options$movement_data$movenet.origin_ID <- origin_ID
 })
 
-test_that("When input datafile is missing, an error is raised", {
+test_that("when input datafile is missing, an error is raised", {
   expect_error(reformat_move_data(), 'argument "move_data_file" is missing, with no default')
 })
 
-test_that("When input datafile does not exist, an error is raised", {
+test_that("when input datafile does not exist, an error is raised", {
   expect_error(reformat_move_data("foo.csv"), 'no such file exists')
 })
 
 test_that("when input datafile misses (a) mandatory col(s), an error is raised", {
   expect_error(reformat_move_data("test_input_files/ScotEID_testdata_colmissing.csv"), "Can't find the following mandatory columns in the datafile\\: departure_date")
   expect_error(reformat_move_data("test_input_files/ScotEID_testdata_2colsmissing.csv"), "Can't find the following mandatory columns in the datafile\\: dest_cph, departure_date")
-#These also raise warnings when run through testthat (though not when the function is run directly on my system?)
-#because lines 33-36 of read_movement_data: I set a column type for a column that doesn't exist, so vroom says: "The following named parsers don't match the column names: departure_date"
-#Is this always silent (if so not a problem)?
 })
 
 test_that("when input datafile misses a requested optional col, a warning is raised and results are produced without the col", {
-  expect_warning(reformat_move_data("test_input_files/ScotEID_testdata_optcolmissing.csv"), "Can't find the following requested optional columns in the datafile\\: movement_reference\\.\n Proceeding without missing optional columns\\.")
+  expect_warning(reformat_move_data("test_input_files/ScotEID_testdata_optcolmissing.csv"), "Can't find the following requested optional columns in the datafile\\: movement_reference\\.\nProceeding without missing optional columns\\.")
   output <- reformat_move_data("test_input_files/ScotEID_testdata_optcolmissing.csv")
   expect_s3_class(output,"data.frame")
   expect_named(output,ScotEID_colnames[c(1:4)])
@@ -60,6 +84,29 @@ test_that("when input datafile misses a requested optional col, a warning is rai
   expect_s3_class(output[[ScotEID_movedata$movenet.move_date]], "POSIXct") #this also works for wrong datetime formats though
   expect_true(all(!is.na(output[[ScotEID_movedata$movenet.move_date]]))) #tests that all dates are interpretable = no NAs generated
   expect_type(output[[ScotEID_movedata$movenet.nr_pigs]], "integer")
+})
+
+test_that("when config has a min col, indicated as col index, that exceeds the col range of input datafile, an error is raised",{
+  suppressMessages(load_config("ScotEID_mincolnrtoolarge"))
+  expect_error(reformat_move_data("test_input_files/ScotEID_testdata.csv"),
+               "Can't find the following mandatory columns in the datafile\\: #20 \\(movenet\\.dest_ID\\)\\.\nThese column indices exceed the number of columns in the datafile\\.")
+  suppressMessages(load_config("ScotEID"))
+})
+
+test_that("when config has an optional col, indicated as col index, that exceeds the col range of input datafile, a warning is raised and results are produced without the col",{
+  suppressMessages(load_config("ScotEID_optcolnrtoolarge"))
+  expect_warning(reformat_move_data("test_input_files/ScotEID_testdata.csv"),
+                 "Can't find the following requested optional columns in the datafile\\: #20 \\(movenet\\.move_ID\\)\\.\nThese column indices exceed the number of columns in the datafile\\.\nProceeding without missing optional columns\\.")
+  output <- reformat_move_data("test_input_files/ScotEID_testdata.csv")
+  expect_s3_class(output,"data.frame")
+  expect_named(output,c(ScotEID_colnames[c(1:4)],"foreign_reference"))
+  expect_type(output[[ScotEID_movedata$movenet.origin_ID]], "character")
+  expect_type(output[[ScotEID_movedata$movenet.dest_ID]], "character")
+  expect_s3_class(output[[ScotEID_movedata$movenet.move_date]], "POSIXct") #this also works for wrong datetime formats though
+  expect_true(all(!is.na(output[[ScotEID_movedata$movenet.move_date]]))) #tests that all dates are interpretable = no NAs generated
+  expect_type(output[[ScotEID_movedata$movenet.nr_pigs]], "integer")
+  expect_type(output[["foreign_reference"]], "character")
+  suppressMessages(load_config("ScotEID"))
 })
 
 test_that("datetime is interpreted correctly, when input has implicit iso format, but some dates are missing (NAs)", {


### PR DESCRIPTION
Reformat_move_data now takes config with int options

Added function that converts int options to column names, if they fall within the range of columns of the datafile.
If a mandatory option is out-of-range, an informative error is raised; if a requested optional option is out-of-range, a warning is raised and the code proceeds without extracting the out-of-range option.
Added appropriate tests.